### PR TITLE
Fix weapon components slots issue

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -24,7 +24,7 @@ end)
 
 -- Helper para buscar el item de arma por serie
 local function GetWeaponItemEntry(Player, serial)
-    for _, item in ipairs(Player.PlayerData.items) do
+    for _, item in pairs(Player.PlayerData.items) do
         if item.type == 'weapon'
         and item.info
         and item.info.serie == serial
@@ -91,7 +91,7 @@ RSGCore.Functions.CreateCallback('rsg-weaponcomp:server:getItemBySerial', functi
     local Player = RSGCore.Functions.GetPlayer(source)
     if not Player then cb(nil); return end
 
-    for _, item in ipairs(Player.PlayerData.items) do
+    for _, item in pairs(Player.PlayerData.items) do
         if item.type == 'weapon' and item.info and item.info.serie == serial then
             cb({ components = item.info.componentshash})
             return
@@ -297,7 +297,7 @@ end)
 -------------------------------------------
 local function saveWeaponComponents(serial, comps, compslabel, Player)
 
-    for _, item in ipairs(Player.PlayerData.items) do
+    for _, item in pairs(Player.PlayerData.items) do
         if item.type == 'weapon' and item.info.serie == serial then
             item.info.componentshash = (type(comps) == "table" and next(comps)) and comps or nil
             item.info.components = (type(compslabel) == "table" and next(compslabel)) and compslabel or nil

--- a/server/server.lua
+++ b/server/server.lua
@@ -105,7 +105,7 @@ RSGCore.Functions.CreateCallback('rsg-weaponcomp:server:getPlayerWeaponComponent
     local Player = RSGCore.Functions.GetPlayer(source)
     if not Player then cb(nil); return end
 
-    for _, item in ipairs(Player.PlayerData.items) do
+    for _, item in pairs(Player.PlayerData.items) do
         if item.type == 'weapon'
         and item.info
         and item.info.serie == serial


### PR DESCRIPTION
Detailed bug report:
https://discord.com/channels/914413479157448744/1420733206323531796

> Problem:
> When I customize a weapon, the component only applies while the weapon stays in a specific inventory slot.
> If I move the weapon to another slot, the customized components reset back to default.

> There is a bug when a customized weapon is given to another player. The components are not bound to the weapon's serial number (the weapon’s components revert to default upon transfer).